### PR TITLE
Fix imported targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -182,7 +182,6 @@ if(modelutilities_SRCS)
                 NAMELINK_SKIP
             INCLUDES
                 DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-                COMPONENT QtModelUtilities_Development
             ARCHIVE
                 DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 COMPONENT QtModelUtilities_Development


### PR DESCRIPTION
Using imported CMake target causes failure:

```
Imported target "QtModelUtilities::QtModelUtilities" includes non-existent
  path

    "/Users/Username/Work/libs/COMPONENT"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.
```
This is caused by misusing the `install(TARGETS..` CMake command. According to the [docs](https://cmake.org/cmake/help/latest/command/install.html#targets), `INCLUDES DESTINATION` option is followed by the list of paths, as a result, `COMPONENT QtModelUtilities_Development` is interpreted as two directories which apparently do not exist.